### PR TITLE
Add helper method to truncate arrays; Resolves #9

### DIFF
--- a/app/helpers/warclight_helper.rb
+++ b/app/helpers/warclight_helper.rb
@@ -17,4 +17,8 @@ module WarclightHelper
       end
     end, '')
   end
+
+  def return_five(options = {})
+    options[:value][0, 5].join('; ') + '...'
+  end
 end

--- a/lib/generators/warclight/templates/catalog_controller.rb
+++ b/lib/generators/warclight/templates/catalog_controller.rb
@@ -75,8 +75,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'institution', label: 'Institution', link_to_facet: true
     config.add_index_field 'collection_name', label: 'Collection Name', link_to_facet: true
     config.add_index_field 'collection_number', label: 'Collection Number', link_to_facet: true
-    config.add_index_field 'links_domains', label: 'This page links to', link_to_facet: true,
-                                            separator_options: { words_connector: '; ' }
+    config.add_index_field 'links_domains', label: 'This page links to', helper_method: :return_five
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/spec/helpers/warclight_helper_spec.rb
+++ b/spec/helpers/warclight_helper_spec.rb
@@ -20,4 +20,12 @@ RSpec.describe WarclightHelper, type: :helper do
       end
     end
   end
+
+  describe '#return_five' do
+    context 'when a field has more than 5 items' do
+      it 'prints the first 5 items in the array, seperated by ";", and ends with "..."' do
+        expect(helper.return_five(value: %w[a b c d e f])).to eq('a; b; c; d; e...')
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Truncate fields that are arrays over 5 items;
* Add test for helper method;
* Use helper method on links_domains for search results.

See https://github.com/archivesunleashed/warclight/issues/9#issuecomment-335890335 for example

Fire up the test app and check it out, or the TravisCI and CodeCov checks should be sufficient.