### PR TITLE
Update warclight gem install branch to 'main'

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-gem 'warclight', github: 'archivesunleashed/warclight'
+gem 'warclight', github: 'archivesunleashed/warclight', :branch => 'main'
 gem 'blacklight_range_limit', '7.9.1'
 
 run 'bundle install'


### PR DESCRIPTION
It appears `rails new` otherwise tries to use master branch which doesn't exist anymore:

```
$ rails _5.2.4.4_ new testapp -m https://raw.githubusercontent.com/archivesunleashed/warclight/main/template.rb
...
Fetching https://github.com/archivesunleashed/warclight.git
fatal: Needed a single revision
Git error: command `git rev-parse --verify master` in directory /tmp/testapp has failed.
Revision master does not exist in the repository https://github.com/archivesunleashed/warclight.git. Maybe you misspelled it?
If this error persists you could try removing the cache directory '/home/user/.bundle/cache/git/warclight-262a12efd637b38a13c36fcf8226a6b82a5a3a56'
```