### PR TITLE
Docker support added for warclight

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+ARG ALPINE_RUBY_VERSION=3.14
+
+FROM ruby:alpine${ALPINE_RUBY_VERSION}
+
+RUN apk add --update --no-cache \
+  bash \
+  build-base \
+  git \
+  libxml2-dev \
+  libxslt-dev \
+  nodejs \
+  yarn \
+  shared-mime-info \
+  sqlite-dev \
+  tzdata
+
+RUN mkdir /app
+WORKDIR /app
+
+RUN gem update --system && \
+  gem install bundler && \
+  bundle config build.nokogiri --use-system-libraries
+
+RUN gem install rails
+
+COPY template.rb .
+
+RUN rails new warclight -m template.rb
+
+WORKDIR /app/warclight
+
+COPY docker-entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 3000
+
+CMD ["rails", "server", "-b", "0.0.0.0"]
+

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ Then visit [http://localhost:3000](http://localhost:3000). It will also start a 
 
 You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
+### Run with docker
+
+Ensure Docker is installed and configured.
+
+```sh
+$ docker-compose build
+$ docker-compose up
+```
+
+Then visit [http://localhost:3000](http://localhost:3000). It will also start a Solr instance on port 8983.
+
 ### Release a new version of the gem
 
 To release a new version:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.7"
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - ALPINE_RUBY_VERSION=3.14
+    depends_on:
+      - solr
+    ports:
+      - "3000:3000"
+    environment:
+      - SOLR_URL='http://solr:8983/solr/discovery'
+      - RAILS_VERSION= 5.2.4.1
+
+  solr:
+    image: ukwa/webarchive-discovery-solr
+    ports:
+      - "8983:8983"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+rm -f /app/.internal_test_app/tmp/pids/server.pid
+exec "$@"


### PR DESCRIPTION
Docker files added to run Warclight and a test Solr instance.
Roughly following [blacklight](https://github.com/projectblacklight/blacklight) docker approach and official Docker Rails [guidelines](https://docs.docker.com/samples/rails/).

Dockerfile uses Warclight template to create Rails app, as per Warclight [wiki](https://github.com/archivesunleashed/warclight/wiki/Creating%2C-installing%2C-and-running-your-Warclight-application). Let me know if you think this isn't the right approach.

Docker-compose uses UKWA _webarchive-discovery-solr_ image for Solr.

Happy to make any adjustments you think necessary.
