### PR TITLE
Fix docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-ARG ALPINE_RUBY_VERSION=3.14
+ARG ALPINE_RUBY_VERSION=3.11
+ARG RAILS_VERSION=5.2.6
 
 FROM ruby:alpine${ALPINE_RUBY_VERSION}
 
@@ -21,9 +22,9 @@ RUN gem update --system && \
   gem install bundler && \
   bundle config build.nokogiri --use-system-libraries
 
-RUN gem install rails
+COPY Gemfile warclight.gemspec template.rb ./
 
-COPY template.rb .
+RUN gem install rails --version 5.2.6
 
 RUN rails new warclight -m template.rb
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,14 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        - ALPINE_RUBY_VERSION=3.14
+        - ALPINE_RUBY_VERSION=3.11
     depends_on:
       - solr
     ports:
       - "3000:3000"
     environment:
       - SOLR_URL='http://solr:8983/solr/discovery'
-      - RAILS_VERSION= 5.2.4.1
+      - RAILS_VERSION=5.2.6
 
   solr:
     image: ukwa/webarchive-discovery-solr


### PR DESCRIPTION
Docker image was failing to build. Base image of Alpine Ruby needed rolling back to 3.11 and also explicitly set Rails to install v5.2.6. 
Building with v6 of Rails was causing errors with some of its dependencies. 

Also I haven't been able to resolve a particular deprecation warning that occurs throughout building the image.
`DEPRECATION WARNING: This manually engine loading is deprecated and will be removed in v3.0.0. Remove `require "view_component/engine"`. (called from <main> at /usr/local/bundle/bundler/gems/warclight-ebf448c0793f/lib/warclight/engine.rb:3)`
@ruebot any ideas what might fix that warning?